### PR TITLE
changed config to convict format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/index.js
+++ b/index.js
@@ -12,9 +12,9 @@ module.exports = function(customConfig) {
         name: 'TeraServer',
         baucis: true,
         worker: worker    
-    }
+    };
 
     _.merge(config, customConfig);
 
     var foundation = require('terafoundation')(config);
-}
+};

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -6,7 +6,6 @@ module.exports = function(context, app, express) {
 
     /// TODO: This doesn't seem like this belongs here.
     var passport = require('passport');
-
     // Services provided by TeraFoundation
     // TODO: this is assuming these are used all the time.
     // This should be more dynamic in respext to services defined by TeraFoundation
@@ -38,14 +37,14 @@ module.exports = function(context, app, express) {
             // We load Teranaut first.            
             this._plugins.push(loadPlugin('teranaut'));
 
-            if (config.api.plugins && config.api.plugins.length > 0) {
-                for (var i = 0; i < config.api.plugins.length; i++) {
-                    var plugin = loadPlugin(config.api.plugins[i]);
+            if (config.has('plugins') && config.get('plugins').length > 0) {
+                for (var i = 0; i < config.get('plugins').length; i++) {
+                    var plugin = loadPlugin(config.get('plugins')[i]);
                     if (plugin) this._plugins.push(plugin);
                 }
             }
         }
-    }
+    };
 
     function loadPlugin(name) {
         var base = '/pl/' + name;
@@ -59,7 +58,7 @@ module.exports = function(context, app, express) {
         }
         
         if (plugin) {
-            logger.info('Plugin ' + name + ': enabling.')
+            logger.info('Plugin ' + name + ': enabling.');
 
             // TODO: should we just be passing through the foundation context?
             plugin.config({
@@ -105,4 +104,4 @@ module.exports = function(context, app, express) {
             return object[func](deferred);
         }
     }
-}
+};

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,5 +3,5 @@
 var app = module.parent.exports;
 
 app.get('/', function(req, res) {
-    res.send(500, 'Invalid request');
+    res.status(500).send('Invalid request');
 });

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -20,12 +20,13 @@ module.exports = function(context) {
     var logger = context.logger;
     var cluster = context.cluster;
     var config = context.sysconfig;
+
     if (context.redis && context.redis.default) var redis_client = context.redis.default;
 
-    var app = module.exports = express();   
+    var app = module.exports = express();
     module.exports.app = app;
 
-    app.set('port', config.api.port || 3000);
+    app.set('port', config.get('port') || 3000);
   
     //app.use(express.favicon());
     app.set('view engine', 'ejs');
@@ -43,7 +44,7 @@ module.exports = function(context) {
         saveUninitialized: false
     };
 
-    if (config.teraserver && config.teraserver.redis_sessions) {
+    if (config.has('teraserver_redis_session') && config.get('teraserver_redis_session')) {
         logger.info("Configuring for session storage in Redis.");
         sessionConfig.store = new RedisStore({ 
             client: redis_client
@@ -75,11 +76,13 @@ module.exports = function(context) {
     app.use(errorHandler);
 
     var server;
-    if (fs.existsSync(config.api.ssl_path + '/key.pem')) {
+    //TODO this below needs to be made better
+
+    if (fs.existsSync(config.get('ssl_path') + '/key.pem')) {
         var options = {
-            key: fs.readFileSync(config.api.ssl_path + '/key.pem'),
-            cert: fs.readFileSync(config.api.ssl_path + '/cert.pem'),
-            ca: fs.readFileSync(config.api.ssl_path + '/gd_bundle-g2-g1.crt')
+            key: fs.readFileSync(config.get('ssl_path') + '/key.pem'),
+            cert: fs.readFileSync(config.get('ssl_path') + '/cert.pem'),
+            ca: fs.readFileSync(config.get('ssl_path') + '/gd_bundle-g2-g1.crt')
         };
         
         logger.info('Starting in SSL mode');

--- a/plugins/teranaut/index.js
+++ b/plugins/teranaut/index.js
@@ -18,7 +18,7 @@ var api = {
         var modelConfig = {
             mongoose: pluginConfig.mongodb,
             logger: logger
-        }
+        };
 
         if (config.teranaut && config.teranaut.models) {
             models = require(config.teranaut.models)(modelConfig);    
@@ -74,24 +74,24 @@ var api = {
 
         this._config.app.post('/login', passport.authenticate('local'), function(req, res) {
             //res.redirect('/');
-            res.send(200, 'login successful');
+            res.status(200).send('login successful');
         });
 
         this._config.app.get('/logout', function(req, res) {
             req.logout();
             //res.redirect('/');
-            res.send(200, 'logout successful');
+            res.status(200).send('login successful');
         });
     },
 
     post: function() {
 
     }
-}
+};
 
 var ensureAuthenticated = function(req, res, next) {
     // We allow creating new accounts without authentication.    
-    if (config.teranaut.auth.open_signup) {
+    if (config.get('teranaut_auth').open_signup) {
         // TODO: THIS URL should depend on the name of the model
         if (req.url === '/accounts' && req.method === 'POST') return next();    
     }
@@ -125,7 +125,7 @@ var ensureAuthenticated = function(req, res, next) {
                 }
             }
             else {
-                return res.json(401, { error: 'Access Denied' });
+                return res.status(401).json({ error: 'Access Denied' });
             }
         })
     }
@@ -133,7 +133,7 @@ var ensureAuthenticated = function(req, res, next) {
         // For session based auth
 
         //res.redirect('/login')
-        return res.json(401, { error: 'Access Denied' });
+        return res.status(401).json({ error: 'Access Denied' });
     }
 }
 
@@ -146,11 +146,11 @@ var login = function(req, res, next) {
         }
 
         if (! user) {
-            return res.json(401, { error: info.message });
+            return res.status(401).json({ error: info.message });
         }
 
         if (config.teranaut.auth && config.teranaut.auth.require_email && ! user.email_validated) {            
-            return res.json(401, { error: 'Account has not been activated' });    
+            return res.status(401).json({ error: 'Account has not been activated' });
         }
 
         req.logIn(user, function(err) {

--- a/plugins/teranaut/server/api/baucis.js
+++ b/plugins/teranaut/server/api/baucis.js
@@ -31,7 +31,7 @@ module.exports = function(config) {
         }
 
         next();
-    }
+    };
 
     node.query('collection', 'get', extensions);
     
@@ -44,7 +44,7 @@ module.exports = function(config) {
         else {
             return res.json(403, { error: 'Access Denied - You don\'t have permission to this data' });
         }
-    }
+    };
 
     // Only admin is allowed to update these data types
     node.request('post put delete', requireAdmin);
@@ -64,7 +64,7 @@ module.exports = function(config) {
             return res.json(403, { error: 'Access Denied - You don\'t have permission to this data' });
         }
 
-    }
+    };
 
     // Admin can update and a user can update their own record, but not change their role
     user.request('get head post put delete', requireUser);
@@ -77,4 +77,4 @@ module.exports = function(config) {
 
         next();
     }
-}
+};

--- a/plugins/teranaut/server/models/Node.js
+++ b/plugins/teranaut/server/models/Node.js
@@ -28,7 +28,7 @@ module.exports = function(config) {
                     enum:       ['Point', 'LineString', 'Polygon'],
                     default:    'Point'
                 },
-                coordinates: [],
+                coordinates: []
             }
         });
 
@@ -37,4 +37,4 @@ module.exports = function(config) {
     }
 
     return model;
-}
+};

--- a/plugins/teranaut/server/models/User.js
+++ b/plugins/teranaut/server/models/User.js
@@ -68,4 +68,4 @@ module.exports = function(config) {
     }
 
     return model;
-}
+};

--- a/plugins/teranaut/server/models/index.js
+++ b/plugins/teranaut/server/models/index.js
@@ -2,7 +2,7 @@ module.exports = function(config) {
     var api = {
         Node: require('./Node.js')(config),
         User: require('./User.js')(config)
-    }
+    };
 
     return api;
-}
+};


### PR DESCRIPTION
This is my config file for convict, its not done and fully documented but you get the idea. This was not tested with other api, just enough to get teraserver up and going.

'use strict';

var convict = require('convict');

var config = convict({
    
    teraserver_redis_session: {
        default: true
    },

    environment: {
        doc: 'The application enviroment',
        format: ['production', 'development'],
        default: 'development',
        env: 'NODE_ENV'
    },
    log_path: {
        doc: 'where to write logs in production mode',
        format: '*',
        default: '/Users/jarednoble/Desktop/logs'
    },
   
    mongo: {
        doc: 'mongo connection',
        default: 'mongodb://localhost:27017/testconfig'
    },
    
    teranaut_auth: {
        default: {
            user_model: 'Account',
            open_signup: true,
            require_email: true
        }
    },
    
    api_workers: {
        doc: 'dont know what this is yet',
        format: 'nat',
        default: 1
    },
    
    port: {
        doc: "The port to bind.",
        format: "port",
        default: 8000,
        env: "PORT"
    },
    plugins: {
        doc: 'list plugins here',
        default: ['teranaut']
    },
    static_assets: {
        default: '/app/api/public'
    },

    ssl_path: {
        default: '/app/config/ssl'
    }
    
});
config.validate();

module.exports = config;