### PR TITLE
Add http deflate support issue#20

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -23,6 +23,7 @@ module.exports = function(context) {
     var routes = require('./routes');
     var canShutDown = true;
 
+    var compression = require('compression');
     var app = module.exports = express();
     module.exports.app = app;
 
@@ -30,6 +31,7 @@ module.exports = function(context) {
     //app.use(express.favicon());
     app.set('view engine', 'ejs');
 
+    app.use(compression());
     app.use(bodyParser.urlencoded({extended: false}));
     app.use(bodyParser.json());
     app.use(methodOverride('X-HTTP-Method-Override'));

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "body-parser": "^1.12.2",
+    "compression": "^1.6.2",
     "connect-redis": "^2.2.0",
     "cookie-parser": "^1.3.4",
     "ejs": "^2.3.1",
@@ -16,8 +17,8 @@
     "lodash": "~2.2.1",
     "method-override": "^2.3.2",
     "passport": "^0.2.1",
-    "passport-local-mongoose": "^0.3.0",
     "passport-local": "~0.1.6",
+    "passport-local-mongoose": "^0.3.0",
     "terafoundation": "terascope/terafoundation"
   }
 }


### PR DESCRIPTION
I have added the npm package 'compression' and made use of it in
the app.  This has the desired effect in the `/pl/logscope` routes
but I am not sure about the API endpoints yet.