### PR TITLE
Search api

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,13 +8,15 @@ var _ = require('lodash');
 module.exports = function(customConfig) {
     var worker = require('./lib/worker');
     var config_schema = require('./system_schema').config_schema;
+    var plugin_schema = require('./system_schema').plugin_schema;
 
 
     var config = {
         name: 'teraserver',
         baucis: true,
         worker: worker,
-        config_schema: config_schema
+        config_schema: config_schema,
+        plugin_schema: plugin_schema
     };
 
     _.merge(config, customConfig);

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,8 +1,9 @@
 var fs = require('fs');
 var _ = require('lodash');
 var getPlugin = require('./utils').getPlugin;
+var search = require('./search');
 
-module.exports = function (context, app, express) {
+module.exports = function(context, app, express) {
     var config = context.sysconfig;
     var logger = context.logger;
 
@@ -21,7 +22,7 @@ module.exports = function (context, app, express) {
     var api = {
         _plugins: [],
 
-        notify: function (phase) {
+        notify: function(phase) {
             var deferred = [];
             for (var i = 0; i < this._plugins.length; i++) {
                 var plugin = this._plugins[i];
@@ -37,14 +38,14 @@ module.exports = function (context, app, express) {
             }
         },
 
-        load: function () {
+        load: function() {
             // We load Teranaut first.
             var plugins = this._plugins;
 
             plugins.push(loadPlugin('teranaut'));
 
-            _.each(config.teraserver.plugins.names, function(name){
-                if(name !== 'teranaut') {
+            _.each(config.teraserver.plugins.names, function(name) {
+                if (name !== 'teranaut') {
                     plugins.push(loadPlugin(name, config))
                 }
             });
@@ -68,7 +69,8 @@ module.exports = function (context, app, express) {
                 elasticsearch: elasticsearch,
                 baucis: baucis,
                 passport: passport,
-                logger: logger
+                logger: logger,
+                search: search
             });
 
             if (_call(plugin, 'static')) {
@@ -79,7 +81,7 @@ module.exports = function (context, app, express) {
                 // aren't conflicting aliases defined by plugins
                 var aliases;
                 if (aliases = _call(plugin, 'aliases')) {
-                    aliases.forEach(function (alias) {
+                    aliases.forEach(function(alias) {
                         logger.info('Plugin ' + name + ': adding static content alias as  /pl/' + alias);
                         app.use('/pl/' + alias + '/', express.static(plugin.static()));
                     })

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,1 +1,478 @@
 'use strict';
+
+var _ = require('lodash');
+
+module.exports = function(appConfig, date_field) {
+    var logger = appConfig.context.foundation.makeLogger('search_module', 'search_module', {module: 'teraserver_search'});
+    
+    /*
+     TODO: This search functionality is fairly generic but assumes some field names
+     date
+     type
+     */
+    function performSearch(context, req, res, config) {
+        if (req.query.size > 100000) {
+            res.status(500).json({error: "Request size too large. Must be less than 100000."});
+            return;
+        }
+
+        var bool_clause;
+
+        // Setup the default query context
+        if (config.query) {
+            // If the query we're running can be run as a filter we do so.
+            // Not every query works as a filter.
+            if (config.nofilter) {
+                context.body = {
+                    'query': {
+                        'bool': {
+                            'must': [
+                                config.query
+                            ]
+                        }
+                    }
+                };
+
+                bool_clause = context.body.query.bool;
+            }
+            else {
+                //TODO verify the whole filtered, filter thing works
+                context.body = {
+                    'query': {
+                        'filtered': {
+                            'filter': {
+                                'bool': {
+                                    'must': [
+                                        config.query
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                };
+
+                bool_clause = context.body.query.filtered.filter.bool;
+            }
+        }
+
+        if (config.date_range) {
+            if (!validateDateRange(res, req.query.date_start, req.query.date_end)) {
+                return;
+            }
+
+            var dateContext = prepareDateRange(req.query.date_start, req.query.date_end);
+            if (dateContext) {
+                bool_clause.must.push(dateContext);
+            }
+        }
+
+        // Geospatial support
+        if (config.geo_field) {
+            var geo_search = geoSearch(req, res, config.geo_field);
+            if (geo_search) {
+                bool_clause.must.push(geo_search);
+            }
+            else {
+                return;
+            }
+        }
+
+        context.size = 100;
+        if (req.query.size) {
+            context.size = req.query.size;
+        }
+
+        if (req.query.start) {
+            context.from = req.query.start;
+        }
+
+        // Parameter to retrieve a particular type of record
+        // TODO: validate incoming type
+        if (req.query.type) {
+            bool_clause.must.push({
+                'term': {
+                    'type': req.query.type
+                }
+            });
+        }
+
+        // See if we should include a default sort
+        if (config.sort_default) {
+            context.sort = config.sort_default;
+        }
+
+        if (config.sort_enabled && req.query.sort) {
+            // split the value and verify
+            var pieces = req.query.sort.split(':');
+            if (config.sort_dates_only && pieces[0].toLowerCase() !== date_field) {
+                res.status(500).json({error: "Invalid sort parameter. Sorting currently available for the '" + date_field + "' field only."});
+                return;
+            }
+
+            if (pieces.length != 2 || (pieces[1].toLowerCase() != 'asc' && pieces[1].toLowerCase() != 'desc')) {
+                res.status(500).json({error: "Invalid sort parameter. Must be field_name:asc or field_name:desc."});
+                return;
+            }
+
+            context.sort = req.query.sort;
+        }
+        var client = config.es_client;
+
+        if (req.query.fields || config.allowed_fields) {
+            var finalFields;
+
+            if (config.allowed_fields) {
+                finalFields = config.allowed_fields;
+            }
+
+            if (req.query.fields) {
+                var fields = _.words(req.query.fields);
+                finalFields = _.filter(fields, function(field) {
+                    if (config.allowed_fields) {
+                        if (config.allowed_fields.indexOf(field) !== -1) {
+                            return true;
+                        }
+                        else {
+                            return false;
+                        }
+                    }
+                    else {
+                        return true;
+                    }
+                });
+            }
+
+            context._sourceInclude = finalFields;
+        }
+
+        client.search(context, function(error, response) {
+            if (error || (response && response.error)) {
+                if (error) {
+                    logger.error("Search error " + error);
+                }
+                else {
+                    logger.error("Search response error " + response.error);
+                }
+
+                res.status(500).json({error: 'Error during query execution.'});
+                return;
+            }
+
+            if (response.hits) {
+                var results = [];
+                for (var i = 0; i < response.hits.hits.length; i++) {
+                    results.push(response.hits.hits[i]._source);
+                }
+
+                var message = response.hits.total + " results found.";
+                if (response.hits.total > context.size) {
+                    message += " Returning " + context.size + "."
+                }
+
+                if (!config.sort_enabled && req.query.sort) {
+                    message += " No sorting available."
+                }
+
+                var final_response = {
+                    info: message,
+                    total: response.hits.total,
+                    returning: +context.size,
+                    results: results
+                };
+
+                if (req.query.pretty) {
+                    res
+                        .set("Content-type", "application/json; charset=utf-8")
+                        .send(JSON.stringify(final_response, null, 2));
+                }
+                else {
+                    res.json(final_response);
+                }
+            }
+            else {
+                res.status(500).json({error: 'No results returned from query.'});
+            }
+        });
+    }
+
+    function luceneWithHistoryQuery(req, res, indexes, config) {
+        // The user can restrict the query to just a subset of indices.
+        // history is taken as "days back from current" or if history_start is
+        // provided "days back from history_start.
+        // TODO: this only works with daily indices
+        if (req.query && req.query.history) {
+            var start = 0;
+            if (req.query.history_start) start = +req.query.history_start;
+
+            var history = +req.query.history;
+            if (Number.isNaN(history) || Number.isNaN(start)) {
+                res.status(500).json({error: "History specification must be numeric."});
+                return;
+            }
+
+            if (history < 0 || start < 0) {
+                res.status(500).json({error: "History specification must be a positive number."});
+                return;
+            }
+
+            if ((history + start) > 90) {
+                res.status(500).json({error: "History is not available beyond 90 days."});
+                return;
+            }
+
+            indexes = indexHistory(history, start, config.history_prefix);
+        }
+
+        luceneQuery(req, res, indexes, config);
+    }
+
+    function luceneQuery(req, res, index, config) {
+        if (!req.query && !req.query.q) {
+            res.status(500).json({error: "Search query must be specified in the query parameter q."});
+            return;
+        }
+
+        var lucQuery = req.query.q;
+
+        // Verify the query string doesn't contain any forms that we need to block
+        var re = RegExp('[^\\s]*.*:[\\s]*[\\*\\?](.*)');
+        if (re.test(lucQuery)) {
+            res.status(500).json({error: "Wild card queries of the form 'fieldname:*value' or 'fieldname:?value' can not be evaluated. Please refer to the documentation on 'fieldname.right'."});
+            return;
+        }
+
+        config.nofilter = true;
+
+        if (config.allowed_fields) {
+            var queryFields = luceneParser(lucQuery);
+            var failures = [];
+
+            for (var key in queryFields) {
+                if (config.allowed_fields.indexOf(key) === -1) {
+                    failures.push(key);
+                }
+            }
+
+            if (failures.length >= 1) {
+                res.status(400).json({error: 'you cannot query on these terms: ' + failures.join('')});
+                return
+            }
+        }
+
+        config.query = {
+            "query_string": {
+                "default_field": "",
+                "query": lucQuery
+            }
+        };
+
+        performSearch({index: index, ignoreUnavailable: true}, req, res, config);
+    }
+
+    function luceneParser(str) {
+        var words = str.split(' ');
+
+        return words.reduce(function(prev, val) {
+            var test = val.match(/:/);
+            if (test) {
+                prev[val.slice(0, test.index)] = true
+            }
+
+            return prev;
+        }, {});
+    }
+
+    function geoSearch(req, res, geo_field) {
+        var query = req.query;
+
+        if (query.geo_box_top_left || query.geo_point) {
+            if (query.geo_box_top_left && query.geo_point) {
+                res.status(500).json({error: "geo_box and geo_distance queries can not be combined."});
+                return;
+            }
+
+            // Handle an Geo Bounding Box query
+            if (query.geo_box_top_left) {
+                var top_left = geo_point(query.geo_box_top_left);
+                if (top_left.length != 2) {
+                    res.status(500).json({error: "Invalid geo_box_top_left"});
+                    return;
+                }
+
+                var bottom_right = geo_point(query.geo_box_bottom_right);
+                if (bottom_right.length != 2) {
+                    res.status(500).json({error: "Invalid geo_box_bottom_right"});
+                    return;
+                }
+
+
+                var search = {
+                    "geo_bounding_box": {}
+                };
+
+                search.geo_bounding_box[geo_field] = {
+                    "top_left": {
+                        "lat": top_left[0],
+                        "lon": top_left[1]
+                    },
+                    "bottom_right": {
+                        "lat": bottom_right[0],
+                        "lon": bottom_right[1]
+                    }
+                };
+
+                return search;
+            }
+
+            // Handle a Geo Distance from point query
+            if (query.geo_distance) {
+                if (!valid_geo_distance(query.geo_distance)) {
+                    res.status(500).json({error: "geo_distance must be in units of 'mi', 'yd', 'ft', 'km' or 'm'"});
+                    return;
+                }
+
+                var location = geo_point(query.geo_point);
+                if (location.length != 2) {
+                    res.status(500).json({error: "Invalid geo_point"});
+                    return;
+                }
+
+                var search = {
+                    "geo_distance": {
+                        "distance": query.geo_distance
+                    }
+                };
+
+                search.geo_distance[geo_field] = {
+                    "lat": location[0],
+                    "lon": location[1]
+                };
+
+                return search;
+            }
+        }
+
+        return {};
+    }
+
+    function valid_geo_distance(distance) {
+        var matches = distance.match(/(\d+)(.*)$/);
+
+        if (!matches) return false;
+
+        var number = matches[1];
+        if (!number) return false;
+
+        var unit = matches[2];
+
+        if (!(unit === 'mi' || unit === 'yd' || unit === 'ft' || unit === 'km' || unit === 'm')) {
+            return false;
+        }
+
+        return true;
+    }
+
+    function geo_point(point) {
+        var pieces = point.split(',');
+        if (pieces.length == 2) {
+            if (pieces[0] > 90 || pieces[0] < -90) {
+                return [];
+            }
+
+            if (pieces[1] > 180 || pieces[1] < -180) {
+                return [];
+            }
+        }
+
+        return pieces;
+    }
+
+    /*
+     * Generates a list of indexes to search based off the API history parameters.
+     */
+    function indexHistory(days, start, history_prefix) {
+        var result = "";
+        var prefix = history_prefix.charAt(history_prefix.length - 1) === '-' ? history_prefix : history_prefix + '-';
+
+        for (var i = start; i < (start + days); i++) {
+            var date = new Date();
+            date.setDate(date.getDate() - i);
+            var dateStr = date.toISOString().slice(0, 10).replace(/-/gi, '.');
+            // example dateStr => logscope-2016.11.11*
+
+            if (result) {
+                result += ',' + prefix + dateStr + '*';
+            }
+            else {
+                result = prefix + dateStr + '*';
+            }
+        }
+
+        return result;
+    }
+
+    function validateDateRange(res, date_start, date_end) {
+        var message = "";
+
+        if (date_start) {
+            date_start = Date.parse(date_start);
+            if (Number.isNaN(date_start)) {
+                message = "date_start is not a valid ISO 8601 date";
+            }
+        }
+
+        if (date_end) {
+            date_end = Date.parse(date_end);
+            if (Number.isNaN(date_end)) {
+                message = "date_end is not a valid ISO 8601 date";
+            }
+        }
+
+        if (date_start && date_end) {
+            if (date_start > date_end) {
+                message = "date_end is before date_start";
+            }
+        }
+        else if (!message) {
+            if (date_end && !date_start) {
+                message = "date_end provided without a corresponding date_start";
+            }
+        }
+
+        if (message) {
+            res.status(500).json({error: message});
+            return false;
+        }
+        else {
+            return true;
+        }
+    }
+
+    function prepareDateRange(date_start, date_end) {
+        var query = {
+            "range": {}
+        };
+
+        query.range[date_field] = {};
+
+        if (date_start && date_end) {
+            query.range[date_field].gte = date_start;
+            query.range[date_field].lte = date_end;
+
+            return query;
+        }
+        else if (date_start) {
+            query.range[date_field].gte = date_start;
+
+            return query;
+        }
+
+        return null;
+    }
+
+    return {
+        luceneQuery: luceneQuery,
+        luceneWithHistoryQuery: luceneWithHistoryQuery,
+        performSearch: performSearch
+    }
+};

--- a/lib/search.js
+++ b/lib/search.js
@@ -3,6 +3,8 @@
 var _ = require('lodash');
 
 module.exports = function(appConfig, date_field) {
+    var appConfig = appConfig;
+    var date_field = date_field;
     var logger = appConfig.context.foundation.makeLogger('search_module', 'search_module', {module: 'teraserver_search'});
 
     /*
@@ -20,42 +22,23 @@ module.exports = function(appConfig, date_field) {
 
         // Setup the default query context
         if (config.query) {
-            // If the query we're running can be run as a filter we do so.
-            // Not every query works as a filter.
-            if (config.nofilter) {
-                context.body = {
-                    'query': {
-                        'bool': {
-                            'must': [
-                                config.query
-                            ]
-                        }
+            context.body = {
+                'query': {
+                    'bool': {
+                        'must': [
+                            config.query
+                        ]
                     }
-                };
+                }
+            };
 
-                bool_clause = context.body.query.bool;
-            }
-            else {
-                //TODO verify the whole filtered, filter thing works
-                context.body = {
-                    'query': {
-                        'bool': {
-                            'must': [
-                                config.query
-                            ]
-                        }
-                    }
-                };
-
-                bool_clause = context.body.query.bool;
-            }
+            bool_clause = context.body.query.bool;
         }
 
         if (config.date_range) {
             if (!validateDateRange(res, req.query.date_start, req.query.date_end)) {
                 return;
             }
-
             var dateContext = prepareDateRange(req.query.date_start, req.query.date_end);
             if (dateContext) {
                 bool_clause.must.push(dateContext);
@@ -223,7 +206,7 @@ module.exports = function(appConfig, date_field) {
     }
 
     function luceneQuery(req, res, index, config) {
-        if (!req.query && !req.query.q) {
+        if (!req.query || !req.query.q) {
             res.status(500).json({error: "Search query must be specified in the query parameter q."});
             return;
         }
@@ -236,9 +219,7 @@ module.exports = function(appConfig, date_field) {
             res.status(500).json({error: "Wild card queries of the form 'fieldname:*value' or 'fieldname:?value' can not be evaluated. Please refer to the documentation on 'fieldname.right'."});
             return;
         }
-
-        config.nofilter = true;
-
+        
         if (config.allowed_fields) {
             var queryFields = luceneParser(lucQuery);
             var failures = [];
@@ -466,9 +447,28 @@ module.exports = function(appConfig, date_field) {
         return null;
     }
 
+    function __test_context(config, d_field) {
+        appConfig = config;
+        date_field = d_field;
+
+        return {
+            performSearch: performSearch,
+            luceneWithHistoryQuery: luceneWithHistoryQuery,
+            luceneQuery: luceneQuery,
+            luceneParser: luceneParser,
+            geoSearch: geoSearch,
+            valid_geo_distance: valid_geo_distance,
+            geo_point: geo_point,
+            indexHistory: indexHistory,
+            validateDateRange: validateDateRange,
+            prepareDateRange: prepareDateRange
+        }
+    }
+
     return {
         luceneQuery: luceneQuery,
         luceneWithHistoryQuery: luceneWithHistoryQuery,
-        performSearch: performSearch
+        performSearch: performSearch,
+        __test_context: __test_context
     }
 };

--- a/lib/search.js
+++ b/lib/search.js
@@ -4,7 +4,7 @@ var _ = require('lodash');
 
 module.exports = function(appConfig, date_field) {
     var logger = appConfig.context.foundation.makeLogger('search_module', 'search_module', {module: 'teraserver_search'});
-    
+
     /*
      TODO: This search functionality is fairly generic but assumes some field names
      date
@@ -39,19 +39,15 @@ module.exports = function(appConfig, date_field) {
                 //TODO verify the whole filtered, filter thing works
                 context.body = {
                     'query': {
-                        'filtered': {
-                            'filter': {
-                                'bool': {
-                                    'must': [
-                                        config.query
-                                    ]
-                                }
-                            }
+                        'bool': {
+                            'must': [
+                                config.query
+                            ]
                         }
                     }
                 };
 
-                bool_clause = context.body.query.filtered.filter.bool;
+                bool_clause = context.body.query.bool;
             }
         }
 
@@ -260,9 +256,9 @@ module.exports = function(appConfig, date_field) {
         }
 
         config.query = {
-            "query_string": {
-                "default_field": "",
-                "query": lucQuery
+            query_string: {
+                default_field: "",
+                query: lucQuery
             }
         };
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "passport": "^0.2.1",
     "passport-local": "~0.1.6",
     "passport-local-mongoose": "^0.3.0",
-    "terafoundation": "terascope/terafoundation"
+    "request": "^2.78.0",
+    "terafoundation": "terascope/terafoundation",
+    "yargs": "^6.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "node service.js"
+    "start": "node service.js",
+    "test": "node node_modules/jasmine/bin/jasmine"
   },
   "dependencies": {
     "body-parser": "^1.12.2",
@@ -14,7 +15,8 @@
     "express": "^4.12.3",
     "express-bunyan-logger": "^1.1.1",
     "express-session": "^1.11.1",
-    "lodash": "~2.2.1",
+    "jasmine": "^2.5.2",
+    "lodash": "~4.17.2",
     "method-override": "^2.3.2",
     "passport": "^0.2.1",
     "passport-local": "~0.1.6",

--- a/spec/search-spec.js
+++ b/spec/search-spec.js
@@ -1,0 +1,430 @@
+'use strict';
+
+var _ = require('lodash');
+
+describe('teraserver search module', function() {
+    var config = {
+        context: {
+            foundation: {
+                makeLogger: function() {
+                }
+            }
+        }
+    };
+
+    var search_module = require('../lib/search')(config);
+
+    it('can parse lucene queries and collect field names', function() {
+        //returns an object with keys that are the fields
+        var parser = search_module.__test_context(config, '').luceneParser;
+        var test1 = parser('a string');
+        var test2 = parser('dog:brown');
+        var test3 = parser('dog:brown AND cat:false');
+        var test4 = parser('dog:brown NOT cat:true');
+        var test5 = parser('url:http://google.com');
+        var test6 = parser("ipv6:eae7:e4b5:3da6:fdb2:aa19:22e4:4dba:d356");
+
+        expect(Object.keys(test1).length).toEqual(0);
+        expect(test2.dog).toBeDefined();
+        expect(test3.dog).toBeDefined();
+        expect(test3.cat).toBeDefined();
+        expect(test4.dog).toBeDefined();
+        expect(test4.cat).toBeDefined();
+        expect(test5.url).toBeDefined();
+        expect(test6.ipv6).toBeDefined();
+    });
+
+    it('prepares date ranges for queries', function() {
+        var prepareDateRange = search_module.__test_context(config, 'created').prepareDateRange;
+        var start = new Date().toISOString();
+        var end = start;
+
+        expect(prepareDateRange()).toEqual(null);
+        expect(prepareDateRange(start)).toEqual({"range": {"created": {"gte": start}}});
+        expect(prepareDateRange(start, end)).toEqual({"range": {"created": {"gte": start, "lte": end}}});
+        expect(prepareDateRange(null, end)).toEqual(null);
+    });
+
+    it('can validate date ranges', function() {
+        var validateDateRange = search_module.__test_context(config, 'created').validateDateRange;
+        var list = [];
+        var res = {
+            status: function() {
+                return this
+            },
+            json: function(val) {
+                list.push(val)
+            }
+        };
+        var date = new Date();
+        var start = date.toISOString();
+        var end = new Date(date.getTime() + 100000).toISOString();
+
+        //null, null is valid
+        expect(validateDateRange(res, null, null)).toEqual(true);
+
+        validateDateRange(res, 'something', null);
+        expect(list.shift().error).toEqual('date_start is not a valid ISO 8601 date');
+
+        validateDateRange(res, null, 'something');
+        expect(list.shift().error).toEqual('date_end is not a valid ISO 8601 date');
+
+        validateDateRange(res, end, start);
+        expect(list.shift().error).toEqual('date_end is before date_start');
+
+        validateDateRange(res, null, end);
+        expect(list.shift().error).toEqual('date_end provided without a corresponding date_start');
+
+        expect(validateDateRange(res, start, end)).toEqual(true);
+    });
+
+    it('index history', function() {
+        var indexHistory = search_module.__test_context(config, 'created').indexHistory;
+        var date = new Date();
+        var dateStr = date.toISOString().slice(0, 10).replace(/-/gi, '.');
+        var dateStr2 = new Date(date.setDate(date.getDate() - 1)).toISOString().slice(0, 10).replace(/-/gi, '.');
+        //setDate mutates the original date, so doing this for dateStr3 is setting it back 2 days from original
+        var dateStr3 = new Date(date.setDate(date.getDate() - 1)).toISOString().slice(0, 10).replace(/-/gi, '.');
+
+
+        expect(indexHistory(1, null, 'logstash')).toEqual('logstash-' + dateStr + '*');
+        expect(indexHistory(2, null, 'logstash')).toEqual('logstash-' + dateStr + '*' + ',logstash-' + dateStr2 + '*');
+        expect(indexHistory(2, 1, 'logstash')).toEqual('logstash-' + dateStr2 + '*' + ',logstash-' + dateStr3 + '*');
+
+    });
+
+    it('geo_point', function() {
+        var geo_point = search_module.__test_context(config, 'created').geo_point;
+
+        expect(geo_point('56.033, 89.839')).toEqual(['56.033', ' 89.839']);
+
+        //higher order function checks and throws the appropriate error
+        expect(geo_point('not a geo point')).toEqual(['not a geo point']);
+        expect(geo_point('156.033, 89.839')).toEqual([]);
+        expect(geo_point('56.033, 189.839')).toEqual([]);
+    });
+
+    it('valid_geo_distance', function() {
+        var valid_geo_distance = search_module.__test_context(config, 'created').valid_geo_distance;
+
+        expect(valid_geo_distance('56mi')).toEqual(true);
+        expect(valid_geo_distance('56yd')).toEqual(true);
+        expect(valid_geo_distance('56ft')).toEqual(true);
+        expect(valid_geo_distance('56km')).toEqual(true);
+        expect(valid_geo_distance('56m')).toEqual(true);
+
+        expect(valid_geo_distance('56 m')).toEqual(false);
+        expect(valid_geo_distance('asdfasdf')).toEqual(false);
+    });
+
+    it('preforms geo search', function() {
+        var geoSearch = search_module.__test_context(config, 'created').geoSearch;
+        var list = [];
+        var res = {
+            status: function() {
+                return this
+            },
+            json: function(val) {
+                list.push(val)
+            }
+        };
+
+        var req1 = {query: {}};
+        var req2 = {query: {geo_box_top_left: '56,89', geo_point: '56,89'}};
+        var req3 = {query: {geo_box_top_left: '56m'}};
+        var req4 = {query: {geo_box_top_left: '56,89', geo_box_bottom_right: '56m'}};
+        var req5 = {query: {geo_box_top_left: '56,89', geo_box_bottom_right: '57,92'}};
+
+        expect(geoSearch(req1, res, 'location')).toEqual({});
+
+        geoSearch(req2, res, 'location');
+        expect(list.shift().error).toEqual("geo_box and geo_distance queries can not be combined.");
+
+        geoSearch(req3, res, 'location');
+        expect(list.shift().error).toEqual("Invalid geo_box_top_left");
+
+        geoSearch(req4, res, 'location');
+        expect(list.shift().error).toEqual("Invalid geo_box_bottom_right");
+
+        expect(geoSearch(req5, res, 'location')).toEqual({
+            geo_bounding_box: {
+                location: {
+                    top_left: {
+                        lat: '56',
+                        lon: '89'
+                    }, bottom_right: {lat: '57', lon: '92'}
+                }
+            }
+        });
+    });
+
+    it('performs search', function() {
+        var performSearch = search_module.__test_context(config, 'created').performSearch;
+
+        var date = new Date();
+        var dateStr = new Date(date.setDate(date.getDate() - 1)).toISOString();
+        var dateStr2 = date.toISOString();
+
+        var context = {};
+
+        var list = [];
+        var res = {
+            status: function() {
+                return this
+            },
+            json: function(val) {
+                list.push(val)
+            }
+        };
+
+        var query;
+        var config = {
+            es_client: {
+                search: function(_query) {
+                    query = _query
+                }
+            }
+        };
+        var config2 = _.extend({query: 'some:Query'}, config);
+        var config3 = _.extend({date_range: true}, config2);
+        var config4 = _.extend({geo_field: 'location'}, config2);
+        var config5 = _.extend({sort_default: 'someDefault'}, config);
+        var config6 = _.extend({sort_enabled: true, sort_dates_only: true}, config);
+        var config7 = _.extend({allowed_fields: 'created'}, config);
+        var config8 = _.extend({allowed_fields: 'otherField'}, config);
+
+        var req1 = {query: {size: 100000000}};
+        var req2 = {query: {}};
+        var req3 = {query: {size: 1000}};
+        var req4 = {query: {date_start: dateStr, date_end: dateStr2}};
+        var req5 = {query: {geo_box_top_left: '56,89', geo_box_bottom_right: '57,92'}};
+        var req6 = {query: {start: 12312412}};
+        var req7 = {query: {start: 12312412, type: 'events'}};
+        var req8 = {query: {sort: 'someField:asc'}};
+        var req9 = {query: {sort: 'created:adsfasd'}};
+        var req10 = {query: {sort: 'created:asc'}};
+        var req11 = {query: {fields: 'created'}};
+
+
+        performSearch({}, req1, res, config);
+        expect(list.shift().error).toEqual("Request size too large. Must be less than 100000.");
+
+        //default query
+        performSearch({}, req2, res, config);
+        expect(query).toEqual({size: 100});
+
+        performSearch({}, req3, res, config);
+        expect(query).toEqual({size: 1000});
+
+        performSearch({}, req2, res, config2);
+        expect(query).toEqual({size: 100, body: {query: {bool: {must: ['some:Query']}}}});
+
+        performSearch({}, req4, res, config3);
+        expect(query).toEqual({
+            size: 100,
+            body: {
+                query: {
+                    bool: {
+                        must: ['some:Query', {range: {created: {gte: dateStr, lte: dateStr2}}}]
+                    }
+                }
+            }
+        });
+
+        performSearch({}, req5, res, config4);
+        expect(query).toEqual({
+            size: 100,
+            body: {
+                query: {
+                    bool: {
+                        must: [
+                            'some:Query',
+                            {
+                                geo_bounding_box: {
+                                    location: {
+                                        top_left: {lat: '56', lon: '89'},
+                                        bottom_right: {lat: '57', lon: '92'}
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+
+        performSearch({}, req6, res, config);
+        expect(query).toEqual({size: 100, from: 12312412});
+
+        performSearch({}, req7, res, config2);
+        expect(query).toEqual({
+            body: {
+                query: {
+                    bool: {
+                        must: ['some:Query', {term: {type: 'events'}}]
+                    }
+                }
+            },
+            size: 100,
+            from: 12312412
+        });
+
+        performSearch({}, req8, res, config5);
+        expect(query).toEqual({size: 100, sort: 'someDefault'});
+
+        performSearch({}, req8, res, config6);
+        expect(list.shift().error).toEqual("Invalid sort parameter. Sorting currently available for the 'created' field only.");
+
+        performSearch({}, req9, res, config6);
+        expect(list.shift().error).toEqual("Invalid sort parameter. Must be field_name:asc or field_name:desc.");
+
+        performSearch({}, req10, res, config6);
+        expect(query).toEqual({size: 100, sort: 'created:asc'});
+
+        performSearch({}, req11, res, config6);
+        expect(query).toEqual({size: 100, _sourceInclude: ['created']});
+
+        performSearch({}, req11, res, config7);
+        expect(query).toEqual({size: 100, _sourceInclude: ['created']});
+
+        performSearch({}, req11, res, config8);
+        expect(query).toEqual({size: 100, _sourceInclude: []});
+    });
+
+    it('lucene query', function() {
+        var luceneQuery = search_module.__test_context(config, 'created').luceneQuery;
+        var index = 'some_index';
+        var list = [];
+        var res = {
+            status: function() {
+                return this
+            },
+            json: function(val) {
+                list.push(val)
+            }
+        };
+
+        var query;
+        var config = {
+            es_client: {
+                search: function(_query) {
+                    query = _query
+                }
+            }
+        };
+
+        var config2 = _.extend({allowed_fields: 'some'}, config);
+        var config3 = _.extend({allowed_fields: 'other'}, config);
+
+        var req1 = {};
+        var req2 = {query: {q: 'some:*Query'}};
+        var req3 = {query: {q: 'some:?Query'}};
+        var req4 = {query: {q: 'some:*'}};
+        var req5 = {query: {q: 'some:Query'}};
+
+
+        luceneQuery(req1, res, index, config);
+        expect(list.shift().error).toEqual("Search query must be specified in the query parameter q.");
+
+        luceneQuery(req2, res, index, config);
+        expect(list.shift().error).toEqual("Wild card queries of the form 'fieldname:*value' or 'fieldname:?value' can not be evaluated. Please refer to the documentation on 'fieldname.right'.");
+
+        luceneQuery(req3, res, index, config);
+        expect(list.shift().error).toEqual("Wild card queries of the form 'fieldname:*value' or 'fieldname:?value' can not be evaluated. Please refer to the documentation on 'fieldname.right'.");
+
+        luceneQuery(req4, res, index, config);
+        expect(list.shift().error).toEqual("Wild card queries of the form 'fieldname:*value' or 'fieldname:?value' can not be evaluated. Please refer to the documentation on 'fieldname.right'.");
+
+        luceneQuery(req5, res, index, config);
+        expect(query).toEqual({
+            index: 'some_index',
+            ignoreUnavailable: true,
+            body: {query: {bool: {must: [{query_string: {default_field: '', query: 'some:Query'}}]}}},
+            size: 100
+        });
+
+        luceneQuery(req5, res, index, config2);
+        expect(query).toEqual({
+            index: 'some_index',
+            ignoreUnavailable: true,
+            body: {query: {bool: {must: [{query_string: {default_field: '', query: 'some:Query'}}]}}},
+            size: 100,
+            _sourceInclude: 'some'
+        });
+
+        luceneQuery(req5, res, index, config3);
+        expect(list.shift().error).toEqual('you cannot query on these terms: some');
+    });
+
+    it('lucene with history query', function() {
+        var luceneWithHistoryQuery = search_module.__test_context(config, 'created').luceneWithHistoryQuery;
+
+        var date = new Date();
+        var dateStr = date.toISOString().slice(0, 10).replace(/-/gi, '.');
+        var dateStr2 = new Date(date.setDate(date.getDate() - 1)).toISOString().slice(0, 10).replace(/-/gi, '.');
+
+        var indexes1 = 'some_index';
+        var indexes2 = 'some_index, other_index';
+
+        var list = [];
+        var res = {
+            status: function() {
+                return this
+            },
+            json: function(val) {
+                list.push(val)
+            }
+        };
+
+        var query;
+        var config = {
+            es_client: {
+                search: function(_query) {
+                    query = _query
+                }
+            },
+            history_prefix: 'logscope-'
+        };
+
+        var req1 = {query: {q: 'some:Query', history: 1, history_start: 0}};
+        var req2 = {query: {q: 'some:Query', history: 1, history_start: 'asdfa'}};
+        var req3 = {query: {q: 'some:Query', history: 'asdfs', history_start: 0}};
+        var req4 = {query: {q: 'some:Query', history: -21, history_start: 0}};
+        var req5 = {query: {q: 'some:Query', history: 1, history_start: -21}};
+        var req6 = {query: {q: 'some:Query', history: 61, history_start: 231}};
+        var req7 = {query: {q: 'some:Query', history: 2, history_start: 0}};
+
+
+        luceneWithHistoryQuery(req1, res, indexes1, config);
+        expect(query).toEqual({
+            index: config.history_prefix + dateStr + '*',
+            ignoreUnavailable: true,
+            body: {query: {bool: {must: [{query_string: {default_field: '', query: 'some:Query'}}]}}},
+            size: 100
+        });
+
+        luceneWithHistoryQuery(req2, res, indexes1, config);
+        expect(list.shift().error).toEqual("History specification must be numeric.");
+
+        luceneWithHistoryQuery(req3, res, indexes1, config);
+        expect(list.shift().error).toEqual("History specification must be numeric.");
+
+        luceneWithHistoryQuery(req4, res, indexes1, config);
+        expect(list.shift().error).toEqual("History specification must be a positive number.");
+
+        luceneWithHistoryQuery(req5, res, indexes1, config);
+        expect(list.shift().error).toEqual("History specification must be a positive number.");
+
+        luceneWithHistoryQuery(req6, res, indexes1, config);
+        expect(list.shift().error).toEqual("History is not available beyond 90 days.");
+
+        luceneWithHistoryQuery(req7, res, indexes2, config);
+        expect(query).toEqual({
+            index: config.history_prefix + dateStr + '*,' + config.history_prefix + dateStr2 + '*',
+            ignoreUnavailable: true,
+            body: {query: {bool: {must: [{query_string: {default_field: '', query: 'some:Query'}}]}}},
+            size: 100
+        });
+    });
+
+});

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
first pass on search api as well as tests
implemented the query: fields=field1,field2,field3 api on the client as well as restrictions on the config: allowed_fields: ['field1', 'field2', 'field3']