### PR TITLE
fix bug preventing queries with multiple colons, resolves #26

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -244,6 +244,23 @@ module.exports = function(appConfig, date_field) {
         luceneQuery(req, res, indexes, config);
     }
 
+    function properQuery(lucQuery, re) {
+        var parts = lucQuery.split(" ");
+        return _.every(parts, function(str) {
+            if (str.match(re)) {
+                //checks for a colon, in-between zero and multiple characters and one or more colons
+                if (str.match(/\:(?=.{0,40}\:+)/gi)) {
+                    return true
+                }
+                return false;
+            }
+            else {
+                //not a potential problem, so return true
+                return true
+            }
+        })
+    }
+
     function luceneQuery(req, res, index, config) {
         if (!req.query || !req.query.q) {
             if (config.require_query !== false) {
@@ -261,8 +278,10 @@ module.exports = function(appConfig, date_field) {
         // Verify the query string doesn't contain any forms that we need to block
         var re = RegExp('[^\\s]*.*:[\\s]*[\\*\\?](.*)');
         if (re.test(lucQuery)) {
-            res.status(500).json({error: "Wild card queries of the form 'fieldname:*value' or 'fieldname:?value' can not be evaluated. Please refer to the documentation on 'fieldname.right'."});
-            return;
+            if (!properQuery(lucQuery, re)) {
+                res.status(500).json({error: "Wild card queries of the form 'fieldname:*value' or 'fieldname:?value' can not be evaluated. Please refer to the documentation on 'fieldname.right'."});
+                return;
+            }
         }
 
         if (config.allowed_fields) {
@@ -282,51 +301,13 @@ module.exports = function(appConfig, date_field) {
         }
 
         if (lucQuery && lucQuery.length > 0) {
-            var _query = {};
-            var multipleColons = lucQuery.split(":");
 
-            //has multiple colons
-            if (multipleColons.length > 2) {
-                var field = multipleColons.shift();
-                var queryBody = multipleColons.join(":");
-                //we already shifted, checking for multiple colons signifying an ipv6 address query
-                if (multipleColons.length >= 2) {
-                    // if a * exists use wildcard (meant for elasticsearch 2.x, ipv6 address could only be strings)
-                    if (queryBody.match(/\*/)) {
-                        _query = {
-                            wildcard: {}
-                        };
-                        _query.wildcard[field] = queryBody;
-                    }
-                    else {
-                        //ipv6 query for 5.x, need to escape query
-                        _query = {
-                            query_string: {
-                                default_field: "",
-                                query: `${field}:\"${queryBody}\"`
-                            }
-                        }
-                    }
+            config.query = {
+                query_string: {
+                    default_field: "",
+                    query: lucQuery
                 }
-                else {
-                    //should be a url type query, use a wildcard
-                    _query = {
-                        wildcard: {}
-                    };
-                    _query.wildcard[field] = queryBody;
-                }
-            }
-            else {
-                //standard lucene query
-                _query = {
-                    query_string: {
-                        default_field: "",
-                        query: lucQuery
-                    }
-                }
-            }
-
-            config.query = _query
+            };
         }
 
         performSearch({index: index, ignoreUnavailable: true}, req, res, config);
@@ -547,7 +528,8 @@ module.exports = function(appConfig, date_field) {
             geo_point: geo_point,
             indexHistory: indexHistory,
             validateDateRange: validateDateRange,
-            prepareDateRange: prepareDateRange
+            prepareDateRange: prepareDateRange,
+            properQuery: properQuery
         }
     }
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -282,12 +282,51 @@ module.exports = function(appConfig, date_field) {
         }
 
         if (lucQuery && lucQuery.length > 0) {
-            config.query = {
-                query_string: {
-                    default_field: "",
-                    query: lucQuery
+            var _query = {};
+            var multipleColons = lucQuery.split(":");
+
+            //has multiple colons
+            if (multipleColons.length > 2) {
+                var field = multipleColons.shift();
+                var queryBody = multipleColons.join(":");
+                //we already shifted, checking for multiple colons signifying an ipv6 address query
+                if (multipleColons.length >= 2) {
+                    // if a * exists use wildcard (meant for elasticsearch 2.x, ipv6 address could only be strings)
+                    if (queryBody.match(/\*/)) {
+                        _query = {
+                            wildcard: {}
+                        };
+                        _query.wildcard[field] = queryBody;
+                    }
+                    else {
+                        //ipv6 query for 5.x, need to escape query
+                        _query = {
+                            query_string: {
+                                default_field: "",
+                                query: `${field}:\"${queryBody}\"`
+                            }
+                        }
+                    }
                 }
-            };
+                else {
+                    //should be a url type query, use a wildcard
+                    _query = {
+                        wildcard: {}
+                    };
+                    _query.wildcard[field] = queryBody;
+                }
+            }
+            else {
+                //standard lucene query
+                _query = {
+                    query_string: {
+                        default_field: "",
+                        query: lucQuery
+                    }
+                }
+            }
+
+            config.query = _query
         }
 
         performSearch({index: index, ignoreUnavailable: true}, req, res, config);

--- a/plugins/teranaut/index.js
+++ b/plugins/teranaut/index.js
@@ -83,7 +83,7 @@ var api = {
                 res.header("X-Frame-Options", "Deny");
 
                 res.sendfile('index.html', {root: __dirname + '/static'});
-            }
+            };
 
             this._config.app.get(url_base, function(req, res) {
                 res.redirect(url_base + '/_'); // redirecting to a path handled by /* path below

--- a/spec/search-spec.js
+++ b/spec/search-spec.js
@@ -45,6 +45,36 @@ describe('teraserver search module', function() {
         expect(prepareDateRange(null, end)).toEqual(null);
     });
 
+    it('can verify if queries are ok', function() {
+        var properQuery = search_module.__test_context(config, 'created').properQuery;
+        var re = RegExp('[^\\s]*.*:[\\s]*[\\*\\?](.*)');
+
+        var query1 = 'url:https://*';
+        var query2 = 'url:https://d*';
+        var query3 = 'url:https:*';
+        var query4 = 'url:https://* AND something:else';
+        var query5 = 'ipv6:03d3*';
+        var query6 = 'ipv6:03d3:*';
+        var query7 = 'ipv6:03d3:sdg9::/28';
+        var query8 = 'ipv6:03d3:sdg9::/28 NOT url:https://*';
+
+        var badQuery1 = 'url:*asdfd';
+        var badQuery2 = 'url:?asdf';
+
+        expect(properQuery(query1, re)).toEqual(true);
+        expect(properQuery(query2, re)).toEqual(true);
+        expect(properQuery(query3, re)).toEqual(true);
+        expect(properQuery(query4, re)).toEqual(true);
+        expect(properQuery(query5, re)).toEqual(true);
+        expect(properQuery(query6, re)).toEqual(true);
+        expect(properQuery(query7, re)).toEqual(true);
+        expect(properQuery(query8, re)).toEqual(true);
+
+        expect(properQuery(badQuery1, re)).toEqual(false);
+        expect(properQuery(badQuery2, re)).toEqual(false);
+
+    });
+
     it('can validate date ranges', function() {
         var validateDateRange = search_module.__test_context(config, 'created').validateDateRange;
         var list = [];
@@ -290,7 +320,7 @@ describe('teraserver search module', function() {
         expect(list.shift().error).toEqual('the fields parameter does not contain any valid fields');
 
         performSearch({}, req12, res, config8);
-        expect(list.shift().error).toEqual('the size parameter must be a number, was given: some string');
+        expect(list.shift().error).toEqual('size parameter must be a valid number, was given some string');
 
     });
 


### PR DESCRIPTION
Example of using queries with colons

Note how querying the ipv6 is different, no *

ES 2.x
mapping: url => string, ipv6 => string
http://localhost:8000/api/v1/logstash?q=url:https://*
http://localhost:8000/api/v1/logstash?q=url:https://d*
http://localhost:8000/api/v1/logstash?q=ipv6:02ea:d*
http://localhost:8000/api/v1/logstash?q=ipv6:02e*


ES 5.x
mapping: url => string, ipv6 => url
http://localhost:8000/api/v1/logstash?q=url:https://*
http://localhost:8000/api/v1/logstash?q=url:https://d*
http://localhost:8000/api/v1/logstash?q=ipv6:027c:a741:6e0a:8185:6eb1:5ccf:b337:30fc
http://localhost:8000/api/v1/logstash?q=ipv6:027c:a741::/9