### PR TITLE
user defined sort prevents default geo distance sort resolves #72

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -82,20 +82,6 @@ module.exports = (_appConfig, _dateField) => {
                 }
             }
 
-            // Geospatial support
-            if (config.geo_field) {
-                const geoSearchQueryData = geoSearch(req, res, config.geo_field);
-                if (geoSearchQueryData === 500) {
-                    // An error has already been sent so just return.
-                    return Promise.resolve(false);
-                }
-
-                if (geoSearchQueryData) {
-                    if (geoSearchQueryData.sort) context.body.sort = [geoSearchQueryData.sort];
-                    boolClause.push(geoSearchQueryData.query);
-                }
-            }
-
             context.size = size;
 
             if (start) {
@@ -135,7 +121,22 @@ module.exports = (_appConfig, _dateField) => {
 
                 context.sort = sort;
             }
+
             const client = config.es_client;
+
+            // Geospatial support, we want this after sort so we can determine default geo sort
+            if (config.geo_field) {
+                const geoSearchQueryData = geoSearch(req, res, config.geo_field, context.sort);
+                if (geoSearchQueryData === 500) {
+                    // An error has already been sent so just return.
+                    return Promise.resolve(false);
+                }
+
+                if (geoSearchQueryData) {
+                    if (geoSearchQueryData.sort) context.body.sort = [geoSearchQueryData.sort];
+                    boolClause.push(geoSearchQueryData.query);
+                }
+            }
 
             if (fields || config.allowed_fields) {
                 if (fields && !validate(res, fields, 'string', 'fields')) return Promise.resolve(false);
@@ -354,7 +355,7 @@ module.exports = (_appConfig, _dateField) => {
         }, {});
     }
 
-    function geoSearch(req, res, geoField) {
+    function geoSearch(req, res, geoField, hasSortDefined) {
         const { query } = req;
         let isGeoSort = false;
         const queryResults = {};
@@ -464,9 +465,12 @@ module.exports = (_appConfig, _dateField) => {
 
                     queryResults.query = search;
                 }
+                // if user defined sort, dont add geo sort unless explicitly defined
+                if (!hasSortDefined || (hasSortDefined && isGeoSort)) {
+                    const locationPoints = parsedGeoSortPoint || location;
+                    queryResults.sort = createGeoSortQuery(locationPoints);
+                }
 
-                const locationPoints = parsedGeoSortPoint || location;
-                queryResults.sort = createGeoSortQuery(locationPoints);
                 return queryResults;
             }
         }

--- a/spec/search-spec.js
+++ b/spec/search-spec.js
@@ -287,9 +287,15 @@ describe('teraserver search module', () => {
         expect(() => geoSearch(req11, res, 'location'))
             .toThrow({ code: 500, error: 'Both geo_point and geo_distance must be provided for a geo_point query.' });
 
+        // This tests no user defined sort with default geo distance sort
         const req12Results = geoSearch(req12, res, 'location');
         expect(req12Results.query).toEqual({ geo_distance: { distance: '1000km', location: { lat: '56', lon: '89' } } });
         expect(req12Results.sort).toEqual({ _geo_distance: { location: { lat: '56', lon: '89' }, order: 'asc', unit: 'm' } });
+
+        // This tests a user defined sort preventing a default geo distance sort
+        const req12Results2 = geoSearch(req12, res, 'location', 'someUserDefined:sort');
+        expect(req12Results2.query).toEqual({ geo_distance: { distance: '1000km', location: { lat: '56', lon: '89' } } });
+        expect(req12Results2.sort).toBeUndefined();
 
         const req13Results = geoSearch(req13, res, 'location');
         expect(req13Results.query).toEqual({ geo_distance: { distance: '1000km', location: { lat: '56', lon: '89' } } });
@@ -298,6 +304,11 @@ describe('teraserver search module', () => {
         const req14Results = geoSearch(req14, res, 'location');
         expect(req14Results.query).toEqual({ geo_distance: { distance: '1000km', location: { lat: '56', lon: '89' } } });
         expect(req14Results.sort).toEqual({ _geo_distance: { location: { lat: '57', lon: '90' }, order: 'asc', unit: 'm' } });
+
+        // This has both a user defined sort and a geo sort combination
+        const req14Results2 = geoSearch(req14, res, 'location', 'someUserDefined:sort');
+        expect(req14Results2.query).toEqual({ geo_distance: { distance: '1000km', location: { lat: '56', lon: '89' } } });
+        expect(req14Results2.sort).toEqual({ _geo_distance: { location: { lat: '57', lon: '90' }, order: 'asc', unit: 'm' } });
     });
 
     it('performs search can query', () => {


### PR DESCRIPTION
NOTE:  if you have default sort enabled from the api endpoint, it will prevent the default geo distance sort. You would have to make an explicit geo sort query.